### PR TITLE
Add shellinabox to replace the removed Web Console, plus small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ After months of testing, OpenRSD seems to be stable. Please put issues on GitHub
 <li>This script is only tested on Raspbian, please make sure you are running a distro based on that, or running Raspbian.</li>
 <li>Once Raspbian (Or Raspbian based OS) is installed, run(Note: The following is just the BARE MINIMUM to get OpenRSD to run properly, PiVPN and Samba must be installed separately!):</li>
 </ol>
-<p><code>sudo apt-get update &amp;&amp; sudo apt-get install git apache2 php5 libapache2-mod-php5 php5-mcrypt expect geoip-bin</code></p>
+<p><code>sudo apt-get update &amp;&amp; sudo apt-get install git apache2 php5 libapache2-mod-php5 php5-mcrypt expect geoip-bin shellinabox</code></p>
 <ol>
 <li>
 <p><b>PLEASE KEEP IN MIND THAT ONCE APACHE IS RUNNING AS A USER WITH SUDO RIGHTS, IT SHOULD NOT BE ACCESSIBLE VIA THE INTERNET TO KEEP SECURITY AS BEST AS POSSIBLE. AND ALTHOUGH NOT AS BIG A DEAL AS BEING INTERNET ACCESSIBLE, PLEASE ALSO NOT THAT THIS CAN STILL CAUSE ISSUES ON LAN. (Say as an example an attacker got on your network, they could try and access the Pi.)</b></p>
@@ -24,6 +24,7 @@ Group pi
 ...Some Config stuff...
 </code></pre>
 </li>
+<li>Then run: <code>sudo sed -i -e "s/SHELLINABOX_ARGS=.*/SHELLINABOX_ARGS=\"--no-beep -t\"/g" /etc/default/shellinabox</code></li>
 <li>Then run: <code>sudo service apache2 restart</code></li>
 <li>Then run: <code>cd /var/www/html</code></li>
 <li>Then run: <code>rm -f index.html</code> *Optional!</li>

--- a/app/auth.php
+++ b/app/auth.php
@@ -6,7 +6,7 @@ function auth($username, $password){
 	$ip = $_SERVER['REMOTE_ADDR'];
 	$cpu = php_uname("m");
 	$chkpasswd = "chkpasswd";
-	if(!file_exists("app/auth_log/$date2.log")){touch("./auth_log/$date2.log");}
+	if(!file_exists("app/auth_log/$date2.log")){touch("app/auth_log/$date2.log");}
 	if(file_exists("app/blocked_ip/".$ip)){
 		
 		file_put_contents("app/auth_log/$date2.log","$date [AUTH] - Authentication for $ip failed!($ip) \n", FILE_APPEND);

--- a/app/functions-orsd.js
+++ b/app/functions-orsd.js
@@ -529,3 +529,8 @@ function IsJsonString(str) {
     }
     return true;
 }
+
+function resize_frame(){
+    var window_height = ( $(document).height() * 7 / 10 );
+    $('#shellinaboxdiv').css('height',window_height+'px');
+}

--- a/css/custom.css
+++ b/css/custom.css
@@ -1,3 +1,12 @@
+iframe#shellinaboxframe,
+div#shellinaboxdiv {
+  margin-top: 8px;
+  padding: 0px 0px 0px 0px; 
+  min-width: 100%;
+  min-height: 100%;
+}
+
+
 .rotate{
     -moz-transition: all 2s linear;
     -webkit-transition: all 2s linear;

--- a/index.php
+++ b/index.php
@@ -1,5 +1,5 @@
 <?php
-session_start();
+if (!isset($_SESSION)) { session_start(); };
 include("app/auth.php");
 //Always push out header...
 $ver = new QuickGit();
@@ -188,6 +188,7 @@ function body(){
           					<li><a href="#" onclick="pageLoad('rpiconfig');"><i class="fa fa-paperclip fa-fw"></i> Raspi-Config</a></li>
           					<li><a href="#" onclick="pageLoad('services');"><i class="fa fa-book fa-fw"></i> Services</a></li>
           					<li><a href="#" onclick="pageLoad('check');"><i class="fa fa-arrow-up fa-fw"></i> Updates</a></li>
+          					<li><a href="#" onclick="pageLoad('shellinabox');"><i class="fa fa-keyboard-o fa-fw"></i> Shell in a Box</a></li>
         				</ul>
       				</li>
                     <li>&nbsp;</li>

--- a/page.php
+++ b/page.php
@@ -3,7 +3,7 @@ $ver = new QuickGit();
 define("OPENRSD", TRUE);
 define("VERSHORT", $ver->version()['short']);
 define("VERLONG", $ver->version()['full']);
-session_start();
+if (!isset($_SESSION)) { session_start(); };
 if(!isset($_SESSION['username'])){
 	die("You must be logged in to view this page!");
 }
@@ -35,6 +35,9 @@ if(isset($_POST['page'])){
 			break;
 		case "services":
 			services();
+			break;
+		case "shellinabox":
+			shellinabox();
 			break;
 		case "init":
 			init();
@@ -106,6 +109,9 @@ function rpiconfig(){
 }
 function services(){
 	include('pages/services.php');
+}
+function shellinabox(){
+	include('pages/shellinabox.php');
 }
 function updates(){
 	include('pages/updates.php');

--- a/pages/dashboard.php
+++ b/pages/dashboard.php
@@ -1,7 +1,7 @@
 <?php if(!defined("OPENRSD")){die();} ?>
 <?php
 //Check for valid session:
-session_start();
+if (!isset($_SESSION)) { session_start(); };
 include('app/functions.php');
 if(!isset($_SESSION['username'])){
 	die("You must be logged in to view this page!");

--- a/pages/shellinabox.php
+++ b/pages/shellinabox.php
@@ -1,0 +1,38 @@
+<?php if(!defined("OPENRSD")){die();} ?>
+<?php
+//Check for valid session:
+if (!isset($_SESSION)) { session_start(); };
+include('app/functions.php');
+if(!isset($_SESSION['username'])){
+	die("You must be logged in to view this page!");
+}
+echo '';
+?>
+<div class="row">
+    <div class="col-lg-12">
+        <h1 class="page-header">Shell in a Box <small><a href="#"><div onClick="pageLoad('shellinabox');" class="fa fa-refresh rotate"></div></a></small></h1>
+    </div>
+</div>
+<script>
+$('.container').onresize = function() {
+  resize_frame();
+};
+
+$(window).onresize = function() {
+  resize_frame();
+};
+
+$(window).onload = function() {
+  resize_frame();
+};
+
+</script>
+<div class="row">
+	<div class="col-md-12">
+		<div id="shellinaboxdiv">
+    		<iframe id="shellinaboxframe" src="http://<?php echo $_SERVER['HTTP_HOST']; ?>:4200/" onload="resize_frame()">
+	    		Your browser does not support inline frames.
+    		</iframe>
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
Added shellinabox to replace the removed Web Console

fixed auth logging  wrong path in app/auth.php

> PHP Warning:  touch(): Unable to create file ./auth_log/01-30-2018.log because No such file or directory in /var/www/html/openrsd/app/auth.php on line 7

fixed some "session already started" notices:

> PHP Notice:  A session had already been started - ignoring session_start() in /var/www/html/openrsd/pages/users.php on line 4