### PR TITLE
Fix the JS error on every pageLoad() caused by status('uptime') on the end

### DIFF
--- a/app/functions-orsd.js
+++ b/app/functions-orsd.js
@@ -19,8 +19,6 @@
 			genModal("Error", "Loading the page failed. Please try again.");
 			load(false);
 		});
-		
-		status('uptime');
     }
 function changePwd(username){
 	document.getElementById("changeUserPasswd").innerHTML = username;


### PR DESCRIPTION
For every page loaded there is a JS error logged in the console of Chrome/Firefox/etc
`Uncaught TypeError: Cannot set property 'innerHTML' of null ...`

After looking at the functionality of **status('uptime')** i think the call in pageLoad() is currently not needed.

