### PR TITLE
Improve package update functionality, extend README with Raspbian Stretch

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,22 @@
 ### What is OpenRSD
 OpenRSD or ORSD is a set of PHP scripts, JS, HTML, and BootStrap CSS to create a beautiful, easy to use, responsive Dashboard to manage Raspbian based distros for the RPi2-3.
 
-After months of testing, OpenRSD seems to be stable. Please put issues on GitHub if you find any bugs. 
+After months of testing, OpenRSD seems to be stable. Please put issues on GitHub if you find any bugs.
 
 
 <h3>OpenRSD How to install &amp; Use</h3>
 <p>Installing OpenRSD is pretty simple to do. Just follow the below instructions:</p>
 <ol>
 <li>This script is only tested on Raspbian, please make sure you are running a distro based on that, or running Raspbian.</li>
-<li>Once Raspbian (Or Raspbian based OS) is installed, run(Note: The following is just the BARE MINIMUM to get OpenRSD to run properly, PiVPN and Samba must be installed separately!):</li>
-</ol>
+<li>Once Raspbian (Or Raspbian based OS) is installed, run(Note: The following is just the BARE MINIMUM to get OpenRSD to run properly, PiVPN and Samba must be installed separately!):
 <p><code>sudo apt-get update &amp;&amp; sudo apt-get install git apache2 php5 libapache2-mod-php5 php5-mcrypt expect geoip-bin shellinabox</code></p>
+In case you have Raspbian Stretch you could set up <b>lighttpd and php7.0-fpm</b> as the BARE MINIMUM:
+<p><code>
+sudo apt-get update && sudo apt-get upgrade -y && 
+sudo apt-get -y install git lighttpd php7.0 php7.0-fpm php7.0-curl php7.0-gd php7.0-intl php7.0-mbstring php7.0-mcrypt php7.0-readline php7.0-xml php7.0-zip php-pear expect geoip-bin shellinabox
+</code></p>
+</li>
+</ol>
 <ol>
 <li>
 <p><b>PLEASE KEEP IN MIND THAT ONCE APACHE IS RUNNING AS A USER WITH SUDO RIGHTS, IT SHOULD NOT BE ACCESSIBLE VIA THE INTERNET TO KEEP SECURITY AS BEST AS POSSIBLE. AND ALTHOUGH NOT AS BIG A DEAL AS BEING INTERNET ACCESSIBLE, PLEASE ALSO NOT THAT THIS CAN STILL CAUSE ISSUES ON LAN. (Say as an example an attacker got on your network, they could try and access the Pi.)</b></p>
@@ -23,9 +29,16 @@ User pi
 Group pi
 ...Some Config stuff...
 </code></pre>
+<p>For Stretch with <b>lighttpd and php7.0-fpm</b> you should run the following to raise the max execution timeout to 300 seconds, allow passwordless sudo for www-data user, and switch php on for lighttpd:</p>
+<pre><code>sudo sed -i -e "s/^max_execution_time =.*/max_execution_time = 300/g" /etc/php/7.0/fpm/php.ini
+echo "www-data ALL=(ALL) NOPASSWD: ALL" | sudo tee --append /etc/sudoers.d/010_pi-nopasswd
+sudo lighttpd-enable-mod fastcgi-php
+sudo service php7.0-fpm force-reload
+sudo service lighttpd force-reload
+</code></pre>
 </li>
 <li>Then run: <code>sudo sed -i -e "s/SHELLINABOX_ARGS=.*/SHELLINABOX_ARGS=\"--no-beep -t\"/g" /etc/default/shellinabox</code></li>
-<li>Then run: <code>sudo service apache2 restart</code></li>
+<li>Then run: <code>sudo service apache2 restart</code> or <code>sudo service lighttpd force-reload</code></li>
 <li>Then run: <code>cd /var/www/html</code></li>
 <li>Then run: <code>rm -f index.html</code> *Optional!</li>
 <li>Then run: <code>git clone https://github.com/mitchellurgero/openrsd</code></li>

--- a/app/scripts/updates_list.sh
+++ b/app/scripts/updates_list.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-sudo apt-get --just-print upgrade 2>&1 | perl -ne 'if (/Inst\s([\w,\-,\d,\.,~,:,\+]+)\s\[([\w,\-,\d,\.,~,:,\+]+)\]\s\(([\w,\-,\d,\.,~,:,\+]+)\)? /i) {print "$1 INSTALLED: $2 AVAILABLE: $3\n"}'
+sudo LC_ALL=C apt-get --just-print upgrade 2>&1 | awk '/^Inst /{ print $2" INSTALLED: "$3" AVAILABLE: "$4; }' | tr -d '[]('

--- a/pages/packages.php
+++ b/pages/packages.php
@@ -6,31 +6,40 @@ include('app/functions.php');
 if(!isset($_SESSION['username'])){
 	die("You must be logged in to view this page!");
 }
-echo '';
+
+$max_exec_time = ini_get('max_execution_time');
+$inipath = php_ini_loaded_file();
+
+$updates = shell_exec("sudo bash ./app/scripts/updates_list.sh");
+$updates_array = explode("\n", $updates);
+$updates_count = (count($updates_array) - 1);
+// echo "\n<!-- \n".$updates."\n -->\n"; /* uncomment to debug updates list response */
 ?>
+
 	<div class="row">
         <div class="col-lg-12">
-            <h1 class="page-header">Package Updates <small><a href="#"><div onClick="pageLoad('packages');" class="fa fa-refresh rotate"></div></a>  &nbsp;&nbsp;&nbsp;<button onClick="apt_update();" class="btn btn-raised btn-info">Get Updates</button> &nbsp;&nbsp;&nbsp;<button onClick="apt_upgrade();" class="btn btn-raised btn-warning">Install Upgrades</button></small></h1>
+<?php
+        if ( $max_exec_time < 300 ) {
+            echo "<h5><span class=\"label label-info\" > <span class=\"fa fa-info-circle\"></span> The processing time limit of PHP is ".$max_exec_time." seconds. This is too low, we suggest to <b>set it to 300</b>, it can be changed for example in <u>".$inipath."</u></span></h5>";
+        }
+?>
+            <h1 class="page-header">Package Updates <small><a href="#"><div onClick="pageLoad('packages');" class="fa fa-refresh rotate"></div></a>  &nbsp;&nbsp;&nbsp;<button onClick="apt_update();" class="btn btn-raised btn-info">Get Updates</button> &nbsp;&nbsp;&nbsp;<button onClick="apt_upgrade();" class="btn btn-raised btn-<?php if($updates_count == 0){ echo "outline-"; } ?>warning" <?php if($updates_count == 0){ echo "disabled "; } ?>>Install Upgrades</button></small></h1>
         </div>
     </div>
     <div class="row">
     	<div class="col-lg-12">
     		<?php
-    			$updates = shell_exec("sudo bash ./app/scripts/updates_list.sh");
-    			//echo "<p>$updates</p>";
-    			$updates_array = explode("\n", $updates);
-    			if(count($updates_array) - 1 == 0){
+                        if($updates_count == 0){
     				echo "<p>There are currently no packages that need updating.</p>";
-    			}
+                        } else {
+                                // Only print the table if updates available, this fixes "Undefined offset:" in the foreach loop
     			echo '<table class="table">';
-    			echo '';
     			?>
     			<thead>
     				<th>Package Name</th>
     				<th>Installed Version</th>
     				<th>New Version</th>
     			</thead>
-    			
     			<?php
     			foreach($updates_array as $upd){
     				$updAr = explode(" ", $upd);
@@ -38,9 +47,9 @@ echo '';
     				$u_installed = $updAr[2];
     				$u_new = $updAr[4];
     				echo '<tr><td>'.$u_name.'</td><td>'.$u_installed.'</td><td>'.$u_new.'</td></tr>'."\n";
-    				
     			}
     			echo '</table>';
+                        }
     		?>
     	</div>
     </div>


### PR DESCRIPTION
- Package update lister script now does not depend on perl, and is language independent
- If there is no update, the 'Install upgrades' button is disabled, and the table is hidden
- if the **max_execution_time** in PHP is less than 300 info is shown about it.
- Extended README with instructions for Raspbian Stretch installing lighttpd, php7.0-fpm, editing sudoers, and setting the max_execution_time