### PR TITLE
 Logout not possible in rare cases

### DIFF
--- a/logout.php
+++ b/logout.php
@@ -1,4 +1,5 @@
 <?php
+if (!isset($_SESSION)) { session_start(); }
 session_unset();
 session_destroy();
 session_start();


### PR DESCRIPTION
If the server thinks session is missing, but the browser still carries a valid sessionid in PHPSESSID cookie the logout breaks with "session_destroy(): Trying to destroy uninitialized session"
Fix: simlpy session_start() if there seems no active session