### PR TITLE
Apt streaming ajax

### DIFF
--- a/app/functions-orsd.js
+++ b/app/functions-orsd.js
@@ -147,41 +147,199 @@ function capitalizeFirstLetter(string) {
 	return string.charAt(0).toUpperCase() + string.slice(1);
 }
 function apt_update(){
-	load(true);
-	document.getElementById("pageContent").innerHTML = "Fetching updates, this may take some time, please wait....";
-	$.ajax({
-		method:'post',
-		url:'./app/packages.php',
-		data:{
-			type:'update'
-		},
-		success:function(result) {
-			document.getElementById("pageContent").innerHTML = result;
-			load(false);
-		}
-		}).fail(function(e) {
-			document.getElementById("pageContent").innerHTML = "Loading the page failed. Please try again.";
-			load(false);
-		});
+    $('#pageContent > div.row > div.col-lg-12 > h1 > small > button.btn.btn-raised.btn-info').removeClass('btn-info').addClass('btn-outline-info disabled');
+    $('#pageContent > div.row > div.col-lg-12 > h1 > small > button.btn.btn-raised.btn-warning').removeClass('btn-warning').addClass('btn-outline-warning disabled');
+    $('#pageContent > div.row > div.col-lg-12 > table.table').hide();
+    var contentrow = document.createElement('div'),
+        contentcol = document.createElement('div'),
+        contentpre = document.createElement('textarea');
+    var winheight = $( window ).height(),
+        navheight = $('nav.navbar.navbar-default').outerHeight(),
+        footnavheight = $('nav.navbar.navbar-inverse.navbar-fixed-bottom').outerHeight(),
+        navheadheight = $('#pageContent > div > div > h1.page-header').outerHeight() + 30,
+        viscontheight = ( winheight - (navheight + footnavheight + navheadheight) - 180 );
+        contentpre.setAttribute('id', 'updatestreamcnt');
+        contentpre.setAttribute('rows', '1');
+        contentpre.setAttribute('cols', '160');
+        contentpre.setAttribute('readonly', true);
+        contentpre.style.maxHeight = viscontheight + 'px';
+        contentpre.style.height = viscontheight + 'px';
+        contentrow.className = 'row';
+        contentcol.className = 'col-lg-12';
+        contentcol.appendChild(contentpre);
+        contentrow.appendChild(contentcol);
+        $('#pageContent').append(contentrow);
+    var pkgbutton = document.createElement('button');
+        pkgbutton.setAttribute('onClick','pageLoad(\'packages\');');
+        pkgbutton.innerHTML = 'reload Package Updates';
+        pkgbutton.className = 'btn btn-raised btn-success';
+    var lastResponseLength = false;
+    var ajaxRequest = $.ajax({
+        type: 'post',
+        url: './app/packages.php',
+        data:{
+            type:'updatestream'
+        },
+        xhrFields: {
+            onprogress: function(e)
+            {
+                var progressResponse;
+                var response = e.currentTarget.response;
+                if(lastResponseLength === false)
+                {
+                    progressResponse = response;
+                    lastResponseLength = response.length;
+                }
+                else
+                {
+                    progressResponse = response.substring(lastResponseLength);
+                    lastResponseLength = response.length;
+                }
+                $('#updatestreamcnt').val( $('#updatestreamcnt').val() + progressResponse);
+                contentpre.scrollTop = contentpre.scrollHeight;
+            }
+        }
+    });
+    ajaxRequest.done(function(data)
+    {
+        $('#updatestreamcnt').after(pkgbutton);
+        console.log('Response Complete');
+    });
+    ajaxRequest.fail(function(error){
+        $('#updatestreamcnt').after(pkgbutton);
+        console.log('Error: ', error);
+    });
+    console.log('Request Sent');
 }
 function apt_upgrade(){
-	load(true);
-	document.getElementById("pageContent").innerHTML = "Installing upgrades... Any errors will be output to the page. This will take some time, please wait...";
-	$.ajax({
-		method:'post',
-		url:'./app/packages.php',
-		data:{
-			type:'upgrade'
-		},
-		success:function(result) {
-			document.getElementById("pageContent").innerHTML = result;
-			load(false);
-		}
-		}).fail(function(e) {
-			document.getElementById("pageContent").innerHTML = "Due to the timeout configured on the server, or your browser, this request timed out. The upgrade is still running on the server though. SSH to check upgrade status is recommended.";
-			genModal("Error", "Due to the timeout configured on the server, or your browser, this request timed out. The upgrade is still running on the server though. SSH to check upgrade status is recommended.");
-			load(false);		
-		});
+    $('#pageContent > div.row > div.col-lg-12 > h1 > small > button.btn.btn-raised.btn-info').removeClass('btn-info').addClass('btn-outline-info disabled');
+    $('#pageContent > div.row > div.col-lg-12 > h1 > small > button.btn.btn-raised.btn-warning').removeClass('btn-warning').addClass('btn-outline-warning disabled');
+    $('#pageContent > div.row > div.col-lg-12 > table.table').hide();
+    var contentrow = document.createElement('div'),
+        contentcol = document.createElement('div'),
+        contentpre = document.createElement('textarea');
+    var winheight = $( window ).height(),
+        navheight = $('nav.navbar.navbar-default').outerHeight(),
+        footnavheight = $('nav.navbar.navbar-inverse.navbar-fixed-bottom').outerHeight(),
+        navheadheight = $('#pageContent > div > div > h1.page-header').outerHeight() + 30,
+        viscontheight = ( winheight - (navheight + footnavheight + navheadheight) - 180 );
+        contentpre.setAttribute('id', 'upgradestreamcnt');
+        contentpre.setAttribute('rows', '1');
+        contentpre.setAttribute('cols', '160');
+        contentpre.setAttribute('readonly', true);
+        contentpre.style.maxHeight = viscontheight + 'px';
+        contentpre.style.height = viscontheight + 'px';
+        contentrow.className = 'row';
+        contentcol.className = 'col-lg-12';
+        contentcol.appendChild(contentpre);
+        contentrow.appendChild(contentcol);
+        $('#pageContent').append(contentrow);
+    var pkgbutton = document.createElement('button');
+        pkgbutton.setAttribute('onClick','pageLoad(\'packages\');');
+        pkgbutton.innerHTML = 'reload Package Updates';
+        pkgbutton.className = 'btn btn-raised btn-success';
+    var lastResponseLength = false;
+    var ajaxRequest = $.ajax({
+        type: 'post',
+        url: './app/packages.php',
+        data:{
+            type:'upgradestream'
+        },
+        xhrFields: {
+            onprogress: function(e)
+            {
+                var progressResponse;
+                var response = e.currentTarget.response;
+                if(lastResponseLength === false)
+                {
+                    progressResponse = response;
+                    lastResponseLength = response.length;
+                }
+                else
+                {
+                    progressResponse = response.substring(lastResponseLength);
+                    lastResponseLength = response.length;
+                }
+                $('#upgradestreamcnt').val( $('#upgradestreamcnt').val() + progressResponse);
+                contentpre.scrollTop = contentpre.scrollHeight;
+            }
+        }
+    });
+    ajaxRequest.done(function(data)
+    {
+        $('#upgradestreamcnt').after(pkgbutton);
+        console.log('Response Complete');
+    });
+    ajaxRequest.fail(function(error){
+        $('#upgradestreamcnt').after(pkgbutton);
+        console.log('Error: ', error);
+    });
+    console.log('Request Sent');
+}
+function apt_distupgrade(){
+    $('#pageContent > div.row > div.col-lg-12 > h1 > small > button.btn.btn-raised.btn-info').removeClass('btn-info').addClass('btn-outline-info disabled');
+    $('#pageContent > div.row > div.col-lg-12 > h1 > small > button.btn.btn-raised.btn-danger').removeClass('btn-danger').addClass('btn-outline-danger disabled');
+    $('#pageContent > div.row > div.col-lg-12 > table.table').hide();
+    var contentrow = document.createElement('div'),
+        contentcol = document.createElement('div'),
+        contentpre = document.createElement('textarea');
+    var winheight = $( window ).height(),
+        navheight = $('nav.navbar.navbar-default').outerHeight(),
+        footnavheight = $('nav.navbar.navbar-inverse.navbar-fixed-bottom').outerHeight(),
+        navheadheight = $('#pageContent > div > div > h1.page-header').outerHeight() + 30,
+        viscontheight = ( winheight - (navheight + footnavheight + navheadheight) - 180 );
+        contentpre.setAttribute('id', 'upgradestreamcnt');
+        contentpre.setAttribute('rows', '1');
+        contentpre.setAttribute('cols', '160');
+        contentpre.setAttribute('readonly', true);
+        contentpre.style.maxHeight = viscontheight + 'px';
+        contentpre.style.height = viscontheight + 'px';
+        contentrow.className = 'row';
+        contentcol.className = 'col-lg-12';
+        contentcol.appendChild(contentpre);
+        contentrow.appendChild(contentcol);
+        $('#pageContent').append(contentrow);
+    var pkgbutton = document.createElement('button');
+        pkgbutton.setAttribute('onClick','pageLoad(\'packagesdist\');');
+        pkgbutton.innerHTML = 'reload Package Updates';
+        pkgbutton.className = 'btn btn-raised btn-success';
+    var lastResponseLength = false;
+    var ajaxRequest = $.ajax({
+        type: 'post',
+        url: './app/packages.php',
+        data:{
+            type:'distupgradestream'
+        },
+        xhrFields: {
+            onprogress: function(e)
+            {
+                var progressResponse;
+                var response = e.currentTarget.response;
+                if(lastResponseLength === false)
+                {
+                    progressResponse = response;
+                    lastResponseLength = response.length;
+                }
+                else
+                {
+                    progressResponse = response.substring(lastResponseLength);
+                    lastResponseLength = response.length;
+                }
+                $('#upgradestreamcnt').val( $('#upgradestreamcnt').val() + progressResponse);
+                contentpre.scrollTop = contentpre.scrollHeight;
+            }
+        }
+    });
+    ajaxRequest.done(function(data)
+    {
+        $('#upgradestreamcnt').after(pkgbutton);
+        console.log('Response Complete');
+    });
+    ajaxRequest.fail(function(error){
+        $('#upgradestreamcnt').after(pkgbutton);
+        console.log('Error: ', error);
+    });
+    console.log('Request Sent');
 }
 function serviceAction(name, type){
 	load(true);
@@ -199,7 +357,7 @@ function serviceAction(name, type){
 		}
 		}).fail(function(e) {
 			genModal("Error", "Due to the timeout configured on the server, or your browser, this request timed out. The command is still running on the server though. SSH to check upgrade status is recommended.");
-			load(false);		
+			load(false);
 		});
 }
 function configSave(){

--- a/app/functions.php
+++ b/app/functions.php
@@ -102,6 +102,21 @@ class OpenRSD
     return $updates_result;
 }
 
+    public static function getPackageDistUpdates()
+{
+    $updates_result=array();
+    $updates_cmd = shell_exec("sudo LC_ALL=C apt-get --just-print dist-upgrade 2>&1");
+    $updates_filter = '/Inst (?<u_name>[\w\-\.\:\+]+) \[(?<u_installed>[\.\d\:\w\-\+\~]+)\] \((?<u_new>[\.\d\:\w\-\+\~]+)/';
+    $updates_result['count'] = preg_match_all($updates_filter, $updates_cmd, $updates_result['array'], PREG_SET_ORDER);
+    $installs_filter = '/Inst (?<i_name>[\w\-\.\:\+]+) \((?<i_new>[\.\d\:\w\-\+\~]+)/';
+    $updates_result['newcount'] = preg_match_all($installs_filter, $updates_cmd, $updates_result['instarray'], PREG_SET_ORDER);
+    $removes_filter = '/Remv (?<r_name>[\w\-\.\:\+]+) \[(?<r_installed>[\.\d\:\w\-\+\~]+)\] /';
+    $updates_result['rmcount'] = preg_match_all($removes_filter, $updates_cmd, $updates_result['rmarray'], PREG_SET_ORDER);
+    $updsum_filter = '/(?<cnt_upg>[\d]+) upgraded, (?<cnt_new>[\d]+) newly installed, (?<cnt_rem>[\d]+) to remove and (?<cnt_notup>[\d]+) not upgraded./';
+    $updates_result['sumcount'] = preg_match_all($updsum_filter, $updates_cmd, $updates_result['updsum_arr'], PREG_SET_ORDER);
+    return $updates_result;
+}
+
     public static function getNetworkInterfaces()
 {
     $adapters_result=array();
@@ -193,3 +208,4 @@ class QuickGit
         return $version;
     }
 }
+

--- a/app/packages.php
+++ b/app/packages.php
@@ -9,51 +9,164 @@ if (!isset($_SESSION['username'])) {
     die("You must be logged in to view this page!");
 }
 switch ($_POST['type']) {
-    case "update":
-        update();
+    case "updatestream":
+        updatestream();
         break;
-    case "upgrade":
-        upgrade();
+    case "upgradestream":
+        upgradestream();
+        break;
+    case "distupgradestream":
+        distupgradestream();
         break;
     default:
-        echo "Error";
+        echo "XHR Error";
         break;
 }
 
-function update()
+function updatestream()
 {
     ob_start();
     set_time_limit(0);
 
     while (@ ob_end_flush()); // end all output buffers if any
-    $proc = popen("sudo LC_ALL=C apt-get update 2>&1", 'r');
+    $descriptorspec = array(
+       0 => array("pipe", "r"),  // stdin is a pipe that the child will read from
+       1 => array("pipe", "w"),  // stdout is a pipe that the child will write to
+       2 => array("pipe", "w") // stderr is a pipe that the child will write to
+    );
+    $cwd = '/tmp';
+    $env = array('PATH' => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', 'SHELL' => '/bin/bash', 'DEBIAN_FRONTEND' => 'noninteractive');
+    $ourcmd = "sudo LC_ALL=C apt-get update";
+    $process = proc_open($ourcmd, $descriptorspec, $pipes, $cwd, $env);
+    if (is_resource($process)) {
+        $unblockstdin = stream_set_blocking( $pipes[0] , false );
+        $unblockstdout = stream_set_blocking( $pipes[1] , false );
+        $unblockstderr = stream_set_blocking( $pipes[2] , false );
 
-    echo '<div class="row"><div class="col-lg-12"><pre>';
-    while (!feof($proc)) {
-        echo fread($proc, 1024);
-        @ ob_flush();
-        @ flush();
+        while (!feof($pipes[1])) {
+            echo fgets($pipes[1], 1024);
+            @ ob_flush();
+            @ flush();
+        }
+        fclose($pipes[1]);
+        fclose($pipes[0]);
+        $processerrors = stream_get_contents($pipes[2]);
+        fclose($pipes[2]);
+        $return_value = proc_close($process);
+        if ( strlen($processerrors) > 0 ) {
+            echo "Errors if happened during run:\n";
+            @ ob_flush();
+            @ flush();
+            echo $processerrors;
+            @ ob_flush();
+            @ flush();
+            if ( $return_value > 0 ) {
+                echo "Command returned $return_value\n";
+                @ ob_flush();
+                @ flush();
+            }
+        }
     }
-    echo '</pre></div></div>';
-    echo '';
-    echo '<button class="btn btn-raised btn-success" onClick="pageLoad(\'packages\');">Back to Package Updates</button>';
+            @ ob_flush();
+            @ flush();
+
 }
 
-function upgrade()
+function upgradestream()
 {
     ob_start();
     set_time_limit(0);
 
     while (@ ob_end_flush()); // end all output buffers if any
-    $proc = popen("sudo LC_ALL=C apt-get upgrade -y 2>&1", 'r');
+    $descriptorspec = array(
+       0 => array("pipe", "r"),  // stdin is a pipe that the child will read from
+       1 => array("pipe", "w"),  // stdout is a pipe that the child will write to
+       2 => array("pipe", "w") // stderr is a pipe that the child will write to
+    );
+    $cwd = '/tmp';
+    $env = array('PATH' => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', 'SHELL' => '/bin/bash', 'DEBIAN_FRONTEND' => 'noninteractive');
+//    $ourcmd = "sudo LC_ALL=C apt-get -s -y upgrade";
+    $ourcmd = "sudo LC_ALL=C apt-get -y upgrade";
+    $process = proc_open($ourcmd, $descriptorspec, $pipes, $cwd, $env);
+    if (is_resource($process)) {
+        $unblockstdin = stream_set_blocking( $pipes[0] , false );
+        $unblockstdout = stream_set_blocking( $pipes[1] , false );
+        $unblockstderr = stream_set_blocking( $pipes[2] , false );
 
-    echo '<div class="row"><div class="col-lg-12"><pre>';
-    while (!feof($proc)) {
-        echo fread($proc, 1024);
-        @ ob_flush();
-        @ flush();
+        while (!feof($pipes[1])) {
+            echo fgets($pipes[1], 1024);
+            @ ob_flush();
+            @ flush();
+        }
+        fclose($pipes[1]);
+        fclose($pipes[0]);
+        $processerrors = stream_get_contents($pipes[2]);
+        fclose($pipes[2]);
+        $return_value = proc_close($process);
+        if ( strlen($processerrors) > 0 ) {
+            echo "Errors if happened during run:\n";
+            @ ob_flush();
+            @ flush();
+            echo $processerrors;
+            @ ob_flush();
+            @ flush();
+            if ( $return_value > 0 ) {
+                echo "Command returned $return_value\n";
+                @ ob_flush();
+                @ flush();
+            }
+        }
     }
-    echo '</pre></div></div>';
-    echo '';
-    echo '<button class="btn btn-success" onClick="pageLoad(\'packages\');">Back to Package Updates</button>';
+            @ ob_flush();
+            @ flush();
+
+}
+function distupgradestream()
+{
+    ob_start();
+    set_time_limit(0);
+
+    while (@ ob_end_flush()); // end all output buffers if any
+    $descriptorspec = array(
+       0 => array("pipe", "r"),  // stdin is a pipe that the child will read from
+       1 => array("pipe", "w"),  // stdout is a pipe that the child will write to
+       2 => array("pipe", "w") // stderr is a pipe that the child will write to
+    );
+    $cwd = '/tmp';
+    $env = array('PATH' => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', 'SHELL' => '/bin/bash', 'DEBIAN_FRONTEND' => 'noninteractive');
+//    $ourcmd = "sudo LC_ALL=C apt-get -s dist-upgrade";
+    $ourcmd = "sudo LC_ALL=C apt-get -y dist-upgrade";
+    $process = proc_open($ourcmd, $descriptorspec, $pipes, $cwd, $env);
+    if (is_resource($process)) {
+        $unblockstdin = stream_set_blocking( $pipes[0] , false );
+        $unblockstdout = stream_set_blocking( $pipes[1] , false );
+        $unblockstderr = stream_set_blocking( $pipes[2] , false );
+
+        while (!feof($pipes[1])) {
+            echo fgets($pipes[1], 1024);
+            @ ob_flush();
+            @ flush();
+        }
+        fclose($pipes[1]);
+        fclose($pipes[0]);
+        $processerrors = stream_get_contents($pipes[2]);
+        fclose($pipes[2]);
+        $return_value = proc_close($process);
+        if ( strlen($processerrors) > 0 ) {
+            echo "Errors if happened during run:\n";
+            @ ob_flush();
+            @ flush();
+            echo $processerrors;
+            @ ob_flush();
+            @ flush();
+            if ( $return_value > 0 ) {
+                echo "Command returned $return_value\n";
+                @ ob_flush();
+                @ flush();
+            }
+        }
+    }
+            @ ob_flush();
+            @ flush();
+
 }

--- a/page.php
+++ b/page.php
@@ -36,6 +36,9 @@ if (isset($_POST['page'])) {
         case "packages":
             packages();
             break;
+        case "packagesdist":
+            packagesdist(); //packages-dist.php
+            break;
         case "rpiconfig":
             rpiconfig();
             break;
@@ -100,6 +103,10 @@ function network()
 function packages()
 {
     include('pages/packages.php');
+}
+function packagesdist()
+{
+    include('pages/packages-dist.php');
 }
 function rpiconfig()
 {

--- a/pages/dashboard.php
+++ b/pages/dashboard.php
@@ -70,7 +70,7 @@ if (!isset($_SESSION['username'])) {
                     </div>
                 </div>
                 <div class="col-lg-4">
-                	<div class="row">
+                	<div class="row col-lg-12">
                 		<div class="panel panel-default">
                                 <div class="panel-heading h3">
 	                            Updates
@@ -84,6 +84,7 @@ if (!isset($_SESSION['username'])) {
                                                                     echo "<p>There are currently no packages that need updating.</p>";
                                                                     $updates_summary = $aptupdates['updsum_arr'][0];
                                                                     echo '<p>'.$updates_summary['cnt_upg'].' upgr, '.$updates_summary['cnt_new'].' new, '.$updates_summary['cnt_rem'].' rem,  '.$updates_summary['cnt_notup'].' not upgr.'."</p>\n";
+                                                                    if ($updates_summary['cnt_notup'] != 0) { echo "<p>See <a href=\"#\" onClick=\"pageLoad('packagesdist');\">Dist-Upgrades</a> for the cause of not upgraded packages</p>\n"; }
                                                                 } else {
                                                                     echo "<p style=\"color:#273c75;\"><b>".$updates_count." package(s) are ready to be updated.</b><br/><a href=\"#\" onClick=\"pageLoad('packages');\">Go to Packages</a></p>";
                                                                 }
@@ -109,7 +110,7 @@ if (!isset($_SESSION['username'])) {
 	                        </div>
 	                    </div>
                 	</div>
-                	<div class="row">
+                	<div class="row col-lg-12">
                 		<div class="panel panel-default">
                                 <div class="panel-heading h3">
 	                            Logged in users

--- a/pages/packages-dist.php
+++ b/pages/packages-dist.php
@@ -14,9 +14,13 @@ if (!isset($_SESSION['username'])) {
 $max_exec_time = ini_get('max_execution_time');
 $inipath = php_ini_loaded_file();
 
-$aptupdates = OpenRSD::getPackageUpdates();
+$aptupdates = OpenRSD::getPackageDistUpdates();
 $updates_count = $aptupdates['count'];
+$installs_count = $aptupdates['newcount'];
+$removes_count = $aptupdates['rmcount'];
 $updates_array = $aptupdates['array'];
+$installs_array = $aptupdates['instarray'];
+$removes_array = $aptupdates['rmarray'];
 // echo "\n<!-- \n".print_r($aptupdates,true)."\n -->\n"; /* uncomment to debug updates list response */
 ?>
 
@@ -27,11 +31,14 @@ $updates_array = $aptupdates['array'];
             echo "<h5><span class=\"label label-info\" > <span class=\"fa fa-info-circle\"></span> The processing time limit of PHP is ".$max_exec_time." seconds. This is too low, we suggest to <b>set it to 300</b>, it can be changed for example in <u>".$inipath."</u></span></h5>";
         }
 ?>
-            <h1 class="page-header">Package Updates <small><a href="#"><div onClick="pageLoad('packages');" class="fa fa-refresh rotate"></div></a>  &nbsp;&nbsp;&nbsp;<button onClick="apt_update();" class="btn btn-raised btn-info">Get Updates</button> &nbsp;&nbsp;&nbsp;<button onClick="apt_upgrade();" class="btn btn-raised btn-<?php if ($updates_count == 0) {
+<?php
+            echo "<h5><span class=\"label label-danger\" > <span class=\"glyphicon glyphicon-exclamation-sign\" aria-hidden=\"true\"></span> The Dist-Upgrade process contains the installation of new packages, and removal of conflicting or unnecessary packages.</span></h5>";
+?>
+            <h1 class="page-header">Dist-Upgrades <small><a href="#"><div onClick="pageLoad('packagesdist');" class="fa fa-refresh rotate"></div></a>  &nbsp;&nbsp;&nbsp;<button onClick="apt_update();" class="btn btn-raised btn-info">Get Updates</button> &nbsp;&nbsp;&nbsp;<button onClick="apt_distupgrade();" class="btn btn-raised btn-<?php if (($updates_count == 0)  && ($installs_count == 0) && ($removes_count == 0)) {
     echo "outline-";
-} ?>warning" <?php if ($updates_count == 0) {
+} ?>danger" <?php if (($updates_count == 0) && ($installs_count == 0) && ($removes_count == 0)) {
     echo "disabled ";
-} ?>>Install Upgrades</button></small></h1>
+} ?>>Install Dist-Upgrades</button></small></h1>
         </div>
     </div>
     <div class="row">
@@ -42,12 +49,13 @@ $updates_array = $aptupdates['array'];
                             $updates_summary = $aptupdates['updsum_arr'][0];
                             //echo "\n<!-- \n".print_r($updates_summary,true)."\n -->\n"; /* uncomment to debug updates list response */
                             echo '<p>'.$updates_summary['cnt_upg'].' upgraded, '.$updates_summary['cnt_new'].' newly installed, '.$updates_summary['cnt_rem'].' to remove and '.$updates_summary['cnt_notup'].' not upgraded.'."</p>\n";
-                            if ($updates_summary['cnt_notup'] != 0) { echo "<p>See <a href=\"#\" onClick=\"pageLoad('packagesdist');\">Dist-Upgrades</a> for the cause of not upgraded packages</p>\n"; }
                         } else {
                             // Only print the table if updates available, this fixes "Undefined offset:" in the foreach loop
                             $updates_summary = $aptupdates['updsum_arr'][0];
                             //echo "\n<!-- \n".print_r($updates_summary,true)."\n -->\n"; /* uncomment to debug updates list response */
                             echo '<p>'.$updates_summary['cnt_upg'].' upgraded, '.$updates_summary['cnt_new'].' newly installed, '.$updates_summary['cnt_rem'].' to remove and '.$updates_summary['cnt_notup'].' not upgraded.'."</p>\n";
+            echo "<h5><span class=\"label label-danger\" > <span class=\"glyphicon glyphicon-exclamation-sign\" aria-hidden=\"true\"></span> Please review carefully the table below before starting the Dist-Upgrade</span></h5>";
+
                             echo '<table class="table">'; ?>
     			<thead>
     				<th>Package Name</th>
@@ -60,6 +68,18 @@ $updates_array = $aptupdates['array'];
                     $u_installed = $upd['u_installed'];
                     $u_new = $upd['u_new'];
                     echo '<tr><td>'.$u_name.'</td><td>'.$u_installed.'</td><td>'.$u_new.'</td></tr>'."\n";
+                }
+    		    echo "<tr><th>New Package</th><th>New Version</th><th>&nbsp;</th></tr>\n";
+                foreach ($installs_array as $instd) {
+                    $i_name = $instd['i_name'];
+                    $i_new = $instd['i_new'];
+                    echo '<tr><td>'.$i_name.'</td><td>'.$i_new.'</td><td>installed</td></tr>'."\n";
+                }
+    		    echo "<tr><th>Removed Package</th><th>Removed Version</th><th>&nbsp;</th></tr>\n";
+                foreach ($removes_array as $rmd) {
+                    $r_name = $rmd['r_name'];
+                    $r_installed = $rmd['r_installed'];
+                    echo '<tr><td>'.$r_name.'</td><td>'.$r_installed.'</td><td>removed</td></tr>'."\n";
                 }
                             echo '</table>';
                         }


### PR DESCRIPTION
New features added: apt ajax-stream, dist-upgrade as shown in #26 
- Replaced apt-update and apt-upgrade with streaming ajax, to allow continous loading of shell responses
- Added parsing of dist-upgrade
- Added page to invoke dist-upgrade
